### PR TITLE
Add GPU index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Transcripción simple con GPU:
 
 ```bash
 python main.py tests/data/test_audio.wav \
-  -o tests/out/salida.jsonl --device cuda --show-progress
+  -o tests/out/salida.jsonl --device cuda --device-index 0 --show-progress
 ```
 
 Transcripción simple con CPU (diarización no soportada):
@@ -81,7 +81,7 @@ Transcribir con prompt inicial y beam size:
 ```bash
 python main.py audio.wav \
   --initial-prompt "Hola mundo" --beam-size 2 \
-  --temperature 0.8 -o resultado.jsonl
+  --temperature 0.8 --device cuda --device-index 0 -o resultado.jsonl
 ```
 
 ## Opciones de la CLI

--- a/main.py
+++ b/main.py
@@ -61,6 +61,12 @@ def main():
         help="Dispositivo de cómputo ('cuda' o 'cpu')"
     )
     asr_group.add_argument(
+        "--device-index",
+        type=int,
+        default=0,
+        help="Índice de GPU a utilizar cuando device es 'cuda'",
+    )
+    asr_group.add_argument(
         "--asr-batch",
         type=int,
         default=8, #96
@@ -150,6 +156,7 @@ def main():
         args.threads      = os.cpu_count()
         args.chunk_size   = 15
         args.vad_method   = "silero"
+        args.device_index = 0
 
     # 1. Inicializa hook de progreso
     progress_hook = ForcedProgressHook(transient=True) if args.show_progress else None
@@ -180,6 +187,7 @@ def main():
             audio_file    = args.audio,
             output_jsonl  = args.output,
             device        = args.device,
+            device_index  = args.device_index,
             asr_batch     = args.asr_batch,
             compute_type  = args.compute_type,
             min_speakers  = args.min_speakers,

--- a/src/diarization/diarizer.py
+++ b/src/diarization/diarizer.py
@@ -11,13 +11,15 @@ class Diarizer:
         min_speakers: int = 3,
         max_speakers: int = 15,
         device: str = "cuda",
+        device_index: int = 0,
         models_root: str = "models/pyannote",
         allow_tf32: bool = False,
         progress_hook: ProgressHook = None,
     ):
         self.min_speakers = min_speakers
         self.max_speakers = max_speakers
-        self.use_cuda = (device == "cuda")
+        self.use_cuda = device.startswith("cuda")
+        self.device_index = device_index
         self.models_root = models_root
         self.allow_tf32 = allow_tf32
         self.progress_hook = progress_hook
@@ -30,7 +32,8 @@ class Diarizer:
         pipeline = load_local_pipeline(
             models_root=self.models_root,
             use_cuda=self.use_cuda,
-            allow_tf32=self.allow_tf32
+            allow_tf32=self.allow_tf32,
+            device_index=self.device_index,
         )
         waveform, sample_rate = torchaudio.load(audio_path)
         return pipeline(

--- a/src/diarization/pipeline_loader.py
+++ b/src/diarization/pipeline_loader.py
@@ -13,6 +13,7 @@ def load_local_pipeline(
     models_root: str = "models/pyannote",
     use_cuda: bool = True,
     allow_tf32: bool = False,
+    device_index: int = 0,
 ) -> Pipeline:
     """
     Carga un pipeline de diarización desde config local.
@@ -23,6 +24,7 @@ def load_local_pipeline(
       - use_cuda: si es False, fuerza CPU.
       - allow_tf32: si es True, habilita TF32 para optimizar rendimiento,
         aunque los resultados pueden variar ligeramente.
+      - device_index: GPU a utilizar cuando use_cuda es True.
 
     Retorna:
       Instancia de pyannote.audio.Pipeline en CPU o GPU.
@@ -40,7 +42,7 @@ def load_local_pipeline(
         return pipeline
 
     try:
-        idx = 0
+        idx = device_index
         device = torch.device(f"cuda:{idx}")
         torch.cuda.set_device(device)
         pipeline.to(device)

--- a/src/pipelines/full_pipeline.py
+++ b/src/pipelines/full_pipeline.py
@@ -10,6 +10,7 @@ def run_pipeline(
     audio_file: str,
     output_jsonl: str,
     device: str,
+    device_index: int,
     asr_batch: int,
     compute_type: str,
     min_speakers: int,
@@ -30,12 +31,15 @@ def run_pipeline(
     """
     Ejecuta todo el flujo de trabajo de ASR + alineación + diarización + guardado.
     Todos los parámetros se reciben desde main.py.
+    `device_index` indica qué GPU utilizar cuando hay más de una disponible.
     """
     
 # --- inicio fase ASR-Transcribe ----------------------------------
+    device_str = device if device == "cpu" else f"cuda:{device_index}"
+
     t = Transcriber(
         model_name=model_name,
-        device=device,
+        device=device_str,
         compute_type=compute_type,
         language="es",
         download_root=model_dir,
@@ -71,7 +75,7 @@ def run_pipeline(
         result = t.align(
             result,
             audio_file,
-            device=device,
+            device=device_str,
             return_char_alignments=return_char_alignments,
             on_chunk_end=lambda n: adv_align(n),
         )
@@ -84,6 +88,7 @@ def run_pipeline(
         min_speakers=min_speakers,
         max_speakers=max_speakers,
         device=device,
+        device_index=device_index,
         allow_tf32=allow_tf32,
         progress_hook=progress_hook,
     )


### PR DESCRIPTION
## Summary
- allow selecting GPU device index via CLI
- plumb device_index through the pipeline
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68510e5cd6d48328b473ee8d8c38a3fe